### PR TITLE
Move class "explain" to front

### DIFF
--- a/R/explain.R
+++ b/R/explain.R
@@ -318,7 +318,7 @@ explain.default <- function(object, feature_names = NULL, X = NULL, nsim = 1,
   names(res) <- feature_names
   
   # Add extra `"explain"` class for printing, plotting, etc.
-  class(res) <- c(class(res), "explain")
+  class(res) <- c("explain", class(res))
   res
 
 }

--- a/inst/tinytest/test_fastshap.R
+++ b/inst/tinytest/test_fastshap.R
@@ -66,7 +66,7 @@ expect_identical(
 # Check class 
 expect_identical(
   current = class(shap_all),
-  target = c("tbl_df", "tbl", "data.frame", "explain")
+  target = c("explain", "tbl_df", "tbl", "data.frame")
 )
 
 # Check Shapley-based variable importance
@@ -107,7 +107,7 @@ expect_identical(
 # Check class 
 expect_identical(
   current = class(shap_single),
-  target = c("tbl_df", "tbl", "data.frame", "explain")
+  target = c("explain", "tbl_df", "tbl", "data.frame")
 )
 
 


### PR DESCRIPTION
Small suggestion: move class "explain" in front of the other classes of the resulting explainer object. This makes it easier to write methods for "explain" objects. Needs to be tested though.